### PR TITLE
Fix error on unset destination

### DIFF
--- a/src/main/java/sh/okx/railswitch/database/RailSwitchDatabase.java
+++ b/src/main/java/sh/okx/railswitch/database/RailSwitchDatabase.java
@@ -73,7 +73,7 @@ public class RailSwitchDatabase {
         "SELECT `dest` FROM `%1$s` WHERE `uuid`=?",
         DESTINATION_TABLE);
     removePlayerDestination = String.format(
-        "DELETE FROM `%1$s` WHERE `uuid`=?`,",
+        "DELETE FROM `%1$s` WHERE `uuid`=?",
         DESTINATION_TABLE);
   }
 


### PR DESCRIPTION
Currently throws an error in console when destination is unset, fixed by removing some extra characters at the end of the delete query.