### PR TITLE
Allow spaces in destinations

### DIFF
--- a/src/main/java/sh/okx/railswitch/RailSwitch.java
+++ b/src/main/java/sh/okx/railswitch/RailSwitch.java
@@ -64,7 +64,7 @@ public class RailSwitch extends JavaPlugin {
         && CharMatcher.inRange('0', '9')
         .or(CharMatcher.inRange('a', 'z'))
         .or(CharMatcher.inRange('A', 'Z'))
-        .or(CharMatcher.anyOf("!\"#$%&'()*+,-./;:<=>?@[]\\^_`{|}~")).matchesAllOf(message);
+        .or(CharMatcher.anyOf("!\"#$%&'()*+,-./;:<=>?@[]\\^_`{|}~ ")).matchesAllOf(message);
   }
 
   public boolean isTimings() {

--- a/src/main/java/sh/okx/railswitch/SetDestinationCommand.java
+++ b/src/main/java/sh/okx/railswitch/SetDestinationCommand.java
@@ -27,9 +27,9 @@ public class SetDestinationCommand implements CommandExecutor {
       return true;
     }
 
-    String dest = args[0];
+    String dest = String.join(" ", args);
     if (!plugin.isValidDestination(dest)) {
-      player.sendMessage(ChatColor.RED + "Destinations can not be more than 40 characters and may only use alphanumerical characters and ASCII symbols.");
+      player.sendMessage(ChatColor.RED + "Destinations can not be more than 40 characters and may only use alphanumerical characters, ASCII symbols, and spaces.");
       return true;
     }
 


### PR DESCRIPTION
Allow spaces in destinations because they can be on signs, also rEeEeEe