### PR TITLE
Destination selection signs

### DIFF
--- a/src/main/java/sh/okx/railswitch/RailSwitch.java
+++ b/src/main/java/sh/okx/railswitch/RailSwitch.java
@@ -1,7 +1,9 @@
 package sh.okx.railswitch;
 
 import com.google.common.base.CharMatcher;
+import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import sh.okx.railswitch.database.ConnectionPool;
@@ -67,6 +69,17 @@ public class RailSwitch extends JavaPlugin {
         .or(CharMatcher.inRange('a', 'z'))
         .or(CharMatcher.inRange('A', 'Z'))
         .or(CharMatcher.anyOf("!\"#$%&'()*+,-./;:<=>?@[]\\^_`{|}~")).matchesAllOf(message);
+  }
+
+  public boolean setDestination(Player player, String dest) {
+    if (!isValidDestination(dest)) {
+      player.sendMessage(ChatColor.RED + "Destinations can not be more than 40 characters and may only use alphanumerical characters and ASCII symbols.");
+      return true;
+    }
+
+    getDatabase().setPlayerDestination(player, dest);
+    player.sendMessage(ChatColor.GREEN + "Set your rail destination to: " + dest);
+    return false;
   }
 
   public boolean isTimings() {

--- a/src/main/java/sh/okx/railswitch/RailSwitch.java
+++ b/src/main/java/sh/okx/railswitch/RailSwitch.java
@@ -9,6 +9,7 @@ import sh.okx.railswitch.database.MySQLConnectionPool;
 import sh.okx.railswitch.database.RailSwitchDatabase;
 import sh.okx.railswitch.database.SQLiteConnectionPool;
 import sh.okx.railswitch.listener.DectorRailActivateListener;
+import sh.okx.railswitch.listener.SignInteractListener;
 
 public class RailSwitch extends JavaPlugin {
   private boolean timings;
@@ -27,6 +28,7 @@ public class RailSwitch extends JavaPlugin {
     PluginManager pm = getServer().getPluginManager();
 
     pm.registerEvents(new DectorRailActivateListener(this), this);
+    pm.registerEvents(new SignInteractListener(this), this);
     getCommand("setdestination").setExecutor(new SetDestinationCommand(this));
   }
 

--- a/src/main/java/sh/okx/railswitch/SetDestinationCommand.java
+++ b/src/main/java/sh/okx/railswitch/SetDestinationCommand.java
@@ -28,13 +28,9 @@ public class SetDestinationCommand implements CommandExecutor {
     }
 
     String dest = args[0];
-    if (!plugin.isValidDestination(dest)) {
-      player.sendMessage(ChatColor.RED + "Destinations can not be more than 40 characters and may only use alphanumerical characters and ASCII symbols.");
-      return true;
-    }
 
-    plugin.getDatabase().setPlayerDestination(player, dest);
-    player.sendMessage(ChatColor.GREEN + "Set your rail destination to: " + dest);
+    plugin.setDestination(player, dest);
+
     return true;
   }
 }

--- a/src/main/java/sh/okx/railswitch/listener/SignInteractListener.java
+++ b/src/main/java/sh/okx/railswitch/listener/SignInteractListener.java
@@ -1,0 +1,54 @@
+package sh.okx.railswitch.listener;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import sh.okx.railswitch.RailSwitch;
+public class SignInteractListener implements Listener {
+  private final RailSwitch plugin;
+
+  public SignInteractListener(RailSwitch plugin) {
+    this.plugin = plugin;
+  }
+
+  @EventHandler
+  public void on(PlayerInteractEvent e) {
+    if(e.getAction() == Action.RIGHT_CLICK_BLOCK) {
+      Block b = e.getClickedBlock();
+      if(b.getType() == Material.SIGN_POST || b.getType() == Material.WALL_SIGN) {
+        Sign s = (Sign) b.getState();
+        for(int i = 0; i < 4; i++) {
+          String line = s.getLine(i);
+          if(line.toLowerCase().startsWith("/dest ")) {
+            Player player = e.getPlayer();
+            String dest = line.substring(6);
+
+            trySetDest(player, dest);
+          } else if(i < 3 && line.toLowerCase().endsWith("/dest")) {
+            Player player = e.getPlayer();
+            String dest = s.getLine(i + 1);
+
+            trySetDest(player, dest);
+          }
+        }
+      }
+    }
+  }
+
+  public void trySetDest(Player player, String dest) {
+    if (!plugin.isValidDestination(dest)) {
+      player.sendMessage(ChatColor.RED + "Destinations can not be more than 40 characters and may only use alphanumerical characters and ASCII symbols.");
+      return;
+    }
+
+    plugin.getDatabase().setPlayerDestination(player, dest);
+    player.sendMessage(ChatColor.GREEN + "Set your rail destination to: " + dest);
+    return;
+  }
+}

--- a/src/main/java/sh/okx/railswitch/listener/SignInteractListener.java
+++ b/src/main/java/sh/okx/railswitch/listener/SignInteractListener.java
@@ -30,27 +30,16 @@ public class SignInteractListener implements Listener {
             String dest = line.substring(6);
 
             if(!dest.isEmpty())
-              trySetDest(player, dest);
+              plugin.setDestination(player, dest);
           } else if(i < 3 && line.toLowerCase().endsWith("/dest")) {
             Player player = e.getPlayer();
             String dest = s.getLine(i + 1);
 
             if(!dest.isEmpty())
-              trySetDest(player, dest);
+              plugin.setDestination(player, dest);
           }
         }
       }
     }
-  }
-
-  public void trySetDest(Player player, String dest) {
-    if (!plugin.isValidDestination(dest)) {
-      player.sendMessage(ChatColor.RED + "Destinations can not be more than 40 characters and may only use alphanumerical characters and ASCII symbols.");
-      return;
-    }
-
-    plugin.getDatabase().setPlayerDestination(player, dest);
-    player.sendMessage(ChatColor.GREEN + "Set your rail destination to: " + dest);
-    return;
   }
 }

--- a/src/main/java/sh/okx/railswitch/listener/SignInteractListener.java
+++ b/src/main/java/sh/okx/railswitch/listener/SignInteractListener.java
@@ -29,12 +29,14 @@ public class SignInteractListener implements Listener {
             Player player = e.getPlayer();
             String dest = line.substring(6);
 
-            trySetDest(player, dest);
+            if(!dest.isEmpty())
+              trySetDest(player, dest);
           } else if(i < 3 && line.toLowerCase().endsWith("/dest")) {
             Player player = e.getPlayer();
             String dest = s.getLine(i + 1);
 
-            trySetDest(player, dest);
+            if(!dest.isEmpty())
+              trySetDest(player, dest);
           }
         }
       }


### PR DESCRIPTION
Suggestion: allow players to set their destination be right clicking on signs which specify the destination. Sign can be formatted by starting a line with "/dest " followed by the destination or by ending a line with "/dest" then putting the destination string on the next line. It also might be nice if we added this feature to books, an interactive travel guide sounds like a novel and practical idea.