### PR TITLE
Add an "or" operator using spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ You may also use `[!destination]`, which will activate the rail if a player's de
 2. Go AFK
 3. Arrive
 
+You can also use spaces in a `/dest` command as an "or" operator, like `/dest <destination1> <destination2>`. In this command, RailSwitch will route players towards signs that contain either `<destination1>` or `<destination2>`. 
+
+Another way to think about it is that `/dest` takes multiple arguments. Each argument is a destination that will be checked as you pass a sign.
+
 ### Example Video
 
 [![RailSwitch Demo Video](https://img.youtube.com/vi/GKku2fcB-wY/0.jpg)](https://www.youtube.com/watch?v=GKku2fcB-wY)

--- a/src/main/java/sh/okx/railswitch/RailSwitch.java
+++ b/src/main/java/sh/okx/railswitch/RailSwitch.java
@@ -10,6 +10,8 @@ import sh.okx.railswitch.database.RailSwitchDatabase;
 import sh.okx.railswitch.database.SQLiteConnectionPool;
 import sh.okx.railswitch.listener.DetectorRailActivateListener;
 
+import java.util.Arrays;
+
 public class RailSwitch extends JavaPlugin {
   private boolean timings;
   private RailSwitchDatabase database;
@@ -60,8 +62,14 @@ public class RailSwitch extends JavaPlugin {
    * make sure the message doesn't have any weirdness
    */
   public boolean isValidDestination(String message) {
-    return message.length() <= 40
-        && CharMatcher.inRange('0', '9')
+    // Each destination must be fewer than 40 characters.
+    for (String dest : message.split(" ")) {
+      if (dest.length() <= 40) {
+          return false;
+      }
+    }
+
+    return CharMatcher.inRange('0', '9')
         .or(CharMatcher.inRange('a', 'z'))
         .or(CharMatcher.inRange('A', 'Z'))
         .or(CharMatcher.anyOf("!\"#$%&'()*+,-./;:<=>?@[]\\^_`{|}~ ")).matchesAllOf(message);

--- a/src/main/java/sh/okx/railswitch/RailSwitch.java
+++ b/src/main/java/sh/okx/railswitch/RailSwitch.java
@@ -10,8 +10,6 @@ import sh.okx.railswitch.database.RailSwitchDatabase;
 import sh.okx.railswitch.database.SQLiteConnectionPool;
 import sh.okx.railswitch.listener.DetectorRailActivateListener;
 
-import java.util.Arrays;
-
 public class RailSwitch extends JavaPlugin {
   private boolean timings;
   private RailSwitchDatabase database;

--- a/src/main/java/sh/okx/railswitch/SetDestinationCommand.java
+++ b/src/main/java/sh/okx/railswitch/SetDestinationCommand.java
@@ -29,7 +29,7 @@ public class SetDestinationCommand implements CommandExecutor {
 
     String dest = String.join(" ", args);
     if (!plugin.isValidDestination(dest)) {
-      player.sendMessage(ChatColor.RED + "Destinations can not be more than 40 characters and may only use alphanumerical characters, ASCII symbols, and spaces.");
+      player.sendMessage(ChatColor.RED + "Destinations can each not be more than 40 characters and may only use alphanumerical characters, ASCII symbols, and spaces.");
       return true;
     }
 

--- a/src/main/java/sh/okx/railswitch/listener/DetectorRailActivateListener.java
+++ b/src/main/java/sh/okx/railswitch/listener/DetectorRailActivateListener.java
@@ -78,6 +78,15 @@ public class DetectorRailActivateListener implements Listener {
       if ("*".equals(line) || destination.equalsIgnoreCase(line)) {
         return true;
       }
+
+      // Use spaces as an "or" operator, allowing for more advanced routing.
+      // We preserve the check above for backwards compatibility.
+      String[] destinations = destination.split(" ");
+      for (String dest : destinations) {
+        if (dest.equalsIgnoreCase(line)) {
+          return true;
+        }
+      }
     }
     return false;
   }


### PR DESCRIPTION
When using `/dest`, you can now set multiple destinations by seperating each destination with a space. If any of the destinations match a destination on the sign, you will be routed towards that sign. In this way, you can do more complicated routing with a simpler system. 

Notibly, you can create a server-wide RailSwitch network without going insane placing every destination in every station.

In addition, you can still write a destination on a sign with spaces and it'll still work as expected. However, if one of the words in the destination is another destination in the network, players may be routed wrongly after this update.